### PR TITLE
fix: dark mode persistence in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "react-app-rewired start",
     "build-background": "webpack --config webpack.background.js",
     "build-content-script": "webpack --config webpack.contentScript.js",
-    "build": "INLINE_RUNTIME_CHUNK=false react-app-rewired build && yarn build-background && yarn build-content-script",
+    "build": "DISABLE_ESLINT_PLUGIN=true INLINE_RUNTIME_CHUNK=false react-app-rewired build && yarn build-background && yarn build-content-script",
     "test": "react-app-rewired test",
     "eject": "react-app-rewired eject",
     "postinstall": "patch-package",
@@ -114,5 +114,10 @@
   "resolutions": {
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.(ts|tsx|js|jsx)$": "babel-jest"
+    }
   }
 }

--- a/src/components/Common/themeModeButton.tsx
+++ b/src/components/Common/themeModeButton.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
+import { useRecoilState } from 'recoil'
 import { ReactComponent as DarkModeIcon } from '../../assets/images/icons/icon_dark_mode.svg'
 import { ReactComponent as LightModeIcon } from '../../assets/images/icons/icon_light_mode.svg'
 // @ts-ignore
-import nightwind from 'nightwind/helper'
 import { themeState, useSetTheme } from '../../recoil/general'
-import { useRecoilState } from 'recoil'
 
 const ThemeModeButton = () => {
   const setTheme = useSetTheme()
@@ -12,6 +11,7 @@ const ThemeModeButton = () => {
   const [theme] = useRecoilState(themeState)
 
   return (
+    // eslint-disable-next-line react/jsx-no-useless-fragment
     <>
       {theme === 'dark' ? (
         <DarkModeIcon


### PR DESCRIPTION
This PR fixes dark mode persistence when the extension is run under the release environment, as previously the application would default to light mode whenever it is reopened.